### PR TITLE
Redact Sensitive Info In Logs

### DIFF
--- a/Source/Reai/Api.c
+++ b/Source/Reai/Api.c
@@ -1349,6 +1349,9 @@ static size CURLResponseWriteCallback (void* ptr, size sz, size nmemb, Str* raw_
     return received_size;
 }
 
+
+static bool ua_already_printed = false;
+
 bool MakeRequest (
     Str*        user_agent,
     Str*        api_key,
@@ -1377,8 +1380,6 @@ bool MakeRequest (
         return false;
     }
 
-    LOG_INFO ("REQUEST.URL : %s", request_url->data);
-
     CURL* curl = curl_easy_init();
     if (!curl) {
         LOG_ERROR ("Failed to create a CURL handle. Cannot make requests.");
@@ -1403,13 +1404,18 @@ bool MakeRequest (
     if (request_json && request_json->length) {
         headers = curl_slist_append (headers, "Content-Type: application/json");
         curl_easy_setopt (curl, CURLOPT_POSTFIELDS, request_json->data);
-        LOG_INFO ("request->JSON: '%s'", request_json->data);
+        LOG_INFO ("REQUEST.JSON: '%s'", request_json->data);
     }
 
     Str hdr_ua = StrInit();
     StrPrintf (&hdr_ua, "User-Agent: %s", user_agent->data);
     headers = curl_slist_append (headers, hdr_ua.data);
-    LOG_INFO ("USER_AGENT = %s", hdr_ua.data);
+    
+    if (!ua_already_printed) {
+        LOG_INFO ("USER_AGENT = %s", hdr_ua.data);
+        ua_already_printed = true;
+    }
+
     StrDeinit (&hdr_ua);
 
     curl_easy_setopt (curl, CURLOPT_URL, request_url->data);
@@ -1482,8 +1488,6 @@ bool MakeUploadRequest (
         return false;
     }
 
-    LOG_INFO ("REQUEST.URL : %s", request_url->data);
-
     CURL* curl = curl_easy_init();
     if (!curl) {
         LOG_ERROR ("Failed to create a CURL handle. Cannot make requests.");
@@ -1530,13 +1534,18 @@ bool MakeUploadRequest (
     if (request_json && request_json->length) {
         headers = curl_slist_append (headers, "Content-Type: application/json");
         curl_easy_setopt (curl, CURLOPT_POSTFIELDS, request_json->data);
-        LOG_INFO ("request->JSON: '%s'", request_json->data);
+        LOG_INFO ("REQUEST.JSON: '%s'", request_json->data);
     }
 
     Str hdr_ua = StrInit();
     StrPrintf (&hdr_ua, "User-Agent: %s", user_agent->data);
     headers = curl_slist_append (headers, hdr_ua.data);
-    LOG_INFO ("USER_AGENT = %s", hdr_ua.data);
+    
+    if (!ua_already_printed) {
+        LOG_INFO ("USER_AGENT = %s", hdr_ua.data);
+        ua_already_printed = true;
+    }
+
     StrDeinit (&hdr_ua);
 
     curl_easy_setopt (curl, CURLOPT_MIMEPOST, mime);

--- a/Source/Reai/Config.c
+++ b/Source/Reai/Config.c
@@ -59,8 +59,6 @@ Config ConfigRead (const char *path) {
             kv.value  = StrStrip (VecPtrAt (&kvsplit, 1), " \r\t");
             VecDeinit (&kvsplit);
 
-            LOG_INFO ("Config : Key ('%s') -> Value ('%s')", kv.key.data, kv.value.data);
-
             VecPushBack (&config, kv);
         });
 


### PR DESCRIPTION
Sensitive information like API url and key are dumped in log file at the moment. This PR removes logging of such things. Also removes redundancy of printing user-agent header to log file again and again.